### PR TITLE
make the BLDC controller call the function to update the absolute enc…

### DIFF
--- a/applications/app_uartcomm.c
+++ b/applications/app_uartcomm.c
@@ -449,8 +449,12 @@ void app_uartcomm_start(void)
   initHardware();
 
   mcconf = *mc_interface_get_configuration();
+
+  #if APP_USE_ENCODER
+    encoder_init_abi(mcconf.m_encoder_counts);
+  #endif
   /* (void) getStringPotValue; */
-  mc_interface_set_pid_pos_src(getStringPotValue);
+  // mc_interface_set_pid_pos_src(getStringPotValue);
 
 	is_running = 1;
 
@@ -716,7 +720,6 @@ void updateFeedback(void)
 {
   fb.feedback.motor_current     = mc_interface_get_tot_current();
   fb.feedback.measured_velocity = mc_interface_get_rpm();
-  // fb.feedback.measured_position = mc_interface_get_pid_pos_now();
   fb.feedback.measured_position = encoder_abs_count();
   fb.feedback.supply_voltage    = GET_INPUT_VOLTAGE();
   fb.feedback.supply_current    = mc_interface_get_tot_current_in();

--- a/conf_general.h
+++ b/conf_general.h
@@ -65,6 +65,10 @@
 //#define HW_VERSION_RH
 #endif
 
+// use this to unconditionally configure the encoder, regardless of whether or not that is the
+// source used for commutation
+#define APP_USE_ENCODER true
+
 /*
  * Select default user motor configuration
  */

--- a/encoder.c
+++ b/encoder.c
@@ -211,6 +211,16 @@ float encoder_read_deg(void) {
 	return angle;
 }
 
+void encoder_update_abs_count(void) {
+	switch (mode) {
+	case ENCODER_MODE_ABI:
+		add_encoder_ticks(HW_ENC_TIM->CNT);
+		break;
+	default:
+		break;
+	}
+}
+
 /**
  *  Takes care of all of the logic for keeping track of encoder counts.
  *
@@ -275,12 +285,6 @@ static void add_encoder_ticks(const unsigned int current_enc_count)
 
 	last_enc_count = current_enc_count;
 	enc_abs_count += diff;
-}
-
-enc_abs_count_t encoder_abs_count(void)
-{
-	// add_encoder_ticks(HW_ENC_TIM->CNT);
-	return (enc_abs_count_t)enc_abs_count;
 }
 
 /**
@@ -350,9 +354,21 @@ void encoder_set_counts(uint32_t counts) {
 	}
 }
 
+/**
+ *  Return the number of encoder counts per revolution.
+ */
 uint32_t encoder_counts(void)
 {
 	return enc_counts;
+}
+
+/**
+ *  Return the absolute encoder count, which is the total of all ticks in either direction
+ *  since startup.
+ */
+enc_abs_count_t encoder_abs_count(void)
+{
+	return (enc_abs_count_t)enc_abs_count;
 }
 
 /**

--- a/encoder.h
+++ b/encoder.h
@@ -32,8 +32,17 @@ void encoder_reset(void);
 void encoder_tim_isr(void);
 void encoder_set_counts(uint32_t counts);
 
+// the number of encoder counts per revolution 
 uint32_t encoder_counts(void);
+
+// has the encoder index pin triggered an interrupt since startup??
 bool encoder_index_found(void);
+
+/**
+ *  Update the internal absolute encoder count by examining the current counts in the hardware
+ *  timer that keeps track of encoder pulses.
+ */
+void encoder_update_abs_count(void);
  
 /**
  *  Keep track of absolute encoder ticks since we probably want to use that instead of rotor angle.

--- a/mcpwm.c
+++ b/mcpwm.c
@@ -1311,6 +1311,12 @@ static THD_FUNCTION(rpm_thread, arg) {
 
 		run_pid_control_speed();
 
+
+		// the encoder absolute counts will be updated as a result of run_pid_control_pos,
+		// so only do it here if necessary
+		if ((control_mode != CONTROL_MODE_POS) && encoder_is_configured())
+			encoder_update_abs_count();
+
 		chThdSleepMilliseconds(1);
 	}
 }


### PR DESCRIPTION
…oder counts in the rpm_timer thread, only if it needs to (ie: the encoder counts will be updated as a result of BLDC closed loop position control, so only directly call to update the counts if not in closed loop postion control mode)