### PR TITLE
Cleanup and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,28 @@
 This is the source code for the VESC DC/BLDC/FOC controller. Read more at  
 http://vesc-project.com/
 
-## PFF-BLDC ##
+# PFF-BLDC #
 
 Our vesc interface is done over `UART`, and all communication functionality can be found in `applications/app_uartcomm.c`. Here are some characteristics:
 
 - Feedback is published in response to received commands so the frequency is dictated by that of incoming data. A timer is implemented to provide a minimum feedback frequency of 50Hz if commands aren't being given.
 - Status publishing at 20Hz (configurable via `STATUS_RATE_MS`)
+
+## Driver and Commander ##
+
+The folder `linux_impl` contains a Linux driver to send out commands to a VESC connected over UART. This driver uses the `serial::Serial` library and is intended for use along with an FTDI chip.
+
+## Building/Uploading code ##
+
+Build everything:
+`./scripts/build.sh`
+
+Linux driver:
+`cd linux_impl && catkin_make`
+
+VESC firmware:
+`make` (`make upload` to flash)
+
 
 ## VESC Operation - General Instructions ##
 

--- a/README.md
+++ b/README.md
@@ -5,40 +5,20 @@ http://vesc-project.com/
 
 Our vesc interface is done over `UART`, and all communication functionality can be found in `applications/app_uartcomm.c`. Here are some characteristics:
 
-- Feedback publishing at 50Hz (configurable via `FB_RATE_MS`)
+- Feedback is published in response to received commands so the frequency is dictated by that of incoming data. A timer is implemented to provide a minimum feedback frequency of 50Hz if commands aren't being given.
 - Status publishing at 20Hz (configurable via `STATUS_RATE_MS`)
-- Command frequency is dictated by the Linux/embedded driver, but has been verified to function properly up to ~200Hz.
 
+## VESC Operation - General Instructions ##
 
-## VESC Operation Instructions - Current Control ##
+The base of the code is provided from `vedderb/bldc`, and we have mainly built up higher-level (relatively speaking) code in the `applications` folder which leverages Benjamin's code in order to command the motor and provide feedback for the current status of the system.
 
-We will be using the VESC in BLDC closed loop current control. It's important to note that, whenever the VESC is flashed, it assumes the default configuration, WHICH USES FOC MODE. Whenever you flash new code to the VESC you need to reflash your configuration with the VESC tool so that the proper operation modes are used. A sample config file is located in `config/bldc_testing.xml`.
+The VESC tool allows a user to configure specific motors for operation. FOC is a precise algorithm - even differences between motors of the same make/model will be detected, so **each specific motor will need its own distinct configuration.** It's important to note that, whenever the VESC firmware is flashed (which may be quite frequenctly during development), IT ASSUMES THE DEFAULT CONFIGURATION, which is almost definitely not what you want! **Whenever you flash new code to the VESC you need to reflash your configuration with the VESC tool**! A well tuned motor will easily start up and drive with a `1A` setpoint, while a poorly tuned motor might not move at all.
 
-A well tuned motor will easily start up and drive with a `1A` setpoint, while a poorly tuned motor might not move at all.
+### Things to Remember ###
 
-### Tuning the current control loop ###
-
-The current control PID loop can be found in `mcpwm.c` -> `run_pid_control_current()`. Since BLDC does NOT support closed loop current control out of the box, a new data structure was added to keep track of the PID parameters. These parameters are NOT stored in non-volatile memory and will thus have to be sent over to the VESC every time a `UART` session is initiated OR whenever the VESC is powered off. This method will only be used for development and will be refined later.
-
-`UART` communication with the VESC is done through the `vesc_driver` in `pff-ros-ws`. Current branch is `feature/vesc_driver_current_Control_pid_tuning`. After checking out that branch and building the driver, connect the VESC to the host using the on-board FTDI converter, and run the following command (note that only the port is mandatory - kp/ki/kd will all be `0.0` by default):
-
-```
-roslaunch vesc_driver pid_tuning.launch port:=$PORT kp:=$KP ki:=$KI kd:=$KD 
-```
-
-This will both start a connection with the VESC and launch a dynamic reconfigure server to be used in tuning the PID loop. View the dynamic reconfigure window with `rosrun rqt_reconfigure rqt_reconfigure`. The driver writes PID parameter values to the VESC over UART whenever they are changed (you will see this echoed in `roslaunch` logs).
-
-After launching, commands can be given through something like
-
-```
-rostopic pub /vesc_driver/cmd vesc_driver/Command "target_cmd: 0" --rate 50
-```
-
-or by running `vesc_driver/scripts/commander.py`. This script commands the motor with 1A and 0A alternating at 10 second intervals. It's helpful for observing how an the motor responds to immediate changes in setpoint as well as observing how the actual current
-reaches the setpoint over time.
-
-Use the vesc tool to view values of interest (motor current, duty cycle). Click on the `RT` button on the right-hand side of the vesc tool window, and then click `Realtime Data` in the menu on the left. This will bring up a graphical view.
-
+Some particularly important configuration aspects to always check if the motor isn't moving smoothly:
+1. hall table detection
+2. RL and lambda detection (FOC only)
 
 ## UART Protocol ##
 
@@ -52,6 +32,8 @@ payload length byte (1)
 end byte            (1)
 ```
 
+The packet header and footer around the <`payload bytes`> are provided by the packet interface - please see `application/app_uartcomm.c` for an example of using the packet interface to both send and receive bytes.
+
 The <`payload bytes`> follows our internal message structure. The data types of interest all reside in `applications/control_msgs.h`, and in general, all parsing of those data members should be implemented in `applications/control_msgs.c`.
 
 ```
@@ -59,27 +41,10 @@ packet_type (1)        // member of enum mc_packet_type
 packet_data (variable)
 ```
 
-Here's the packet types currently implemented (packet types are all members of `enum mc_packet_type`):
-
-### CONTROL_WRITE ###
-
-```
-control_mode (1)        // member of enum mc_control_mode
-command      (variable)
-
--------------------------
-
-CONTROL_MODE       ARG LENGTH           ARG DESCRIPTION
-CURRENT                4                Unsigned int representing current in MILLIAMPS
-```
-
-### FEEDBACK_DATA | STATUS_DATA ###
-
-See the structure of these fields in the header file.
+Please see `control_msgs.h` for in-depth descriptions of each message.
 
 ## Configuration and Hall Table Detection (UART) ##
 
-Both of these tasks are handled through the linux driver located in `pff-ros-ws` on the branch `feature/vesc_ros_driver`.
 There is code to handle this, but the messaging protocol has since changed so proper messaging will have to be re-implemented for these features.
 
 # NOTES #

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Our vesc interface is done over `UART`, and all communication functionality can 
 
 The folder `linux_impl` contains a Linux driver to send out commands to a VESC connected over UART. This driver uses the `serial::Serial` library and is intended for use along with an FTDI chip.
 
-## Building/Uploading code ##
+Virtually all other code in this repo pertains to the VESC firmware, including Chibi RTOS, `vedderb`'s VESC firmware on top of that, and our application firmware.
+
+### Building/Uploading code ###
 
 Build everything:
 `./scripts/build.sh`

--- a/applications/app.h
+++ b/applications/app.h
@@ -41,7 +41,6 @@ float app_adc_get_decoded_level2(void);
 float app_adc_get_voltage2(void);
 
 void app_uartcomm_start(void);
-void app_handle_estop_interrupt(void);
 void app_uartcomm_stop(void);
 void app_uartcomm_configure(uint32_t baudrate);
 

--- a/applications/app_uartcomm.c
+++ b/applications/app_uartcomm.c
@@ -674,14 +674,12 @@ void updateFeedback(void)
   fb.feedback.measured_position = encoder_abs_count();
   fb.feedback.supply_voltage    = GET_INPUT_VOLTAGE();
   fb.feedback.supply_current    = mc_interface_get_tot_current_in();
-  fb.feedback.switch_flags      = estop;
+  fb.feedback.estop             = estop;
 }
 
 void updateStatus(void)
 {
   status.status.fault_code = mc_interface_get_fault();
-  status.status.temp       = NTC_TEMP(ADC_IND_TEMP_MOS);
-  status.status.limits_set = 0;
 }
 
 void setCommand()

--- a/applications/control_msgs.h
+++ b/applications/control_msgs.h
@@ -219,7 +219,7 @@ typedef struct {
   uint32_t measured_position;
   float supply_voltage;
   float supply_current;
-  uint32_t switch_flags;
+  uint8_t estop; // 1 if estop is active, 0 otherwise
 } mc_feedback;
 
 // a union to simplify sending feedback over i2c
@@ -234,8 +234,6 @@ typedef union {
 // The struct that represents a status message
 typedef struct {
   uint32_t fault_code;
-  uint32_t temp;
-  bool limits_set;
 } mc_status;
 
 // a union to simplify transferring statuses over i2c

--- a/ext_handler.c
+++ b/ext_handler.c
@@ -1,5 +1,6 @@
 #include "ext_handler.h"
 #include "app.h"
+#include "nvic.h"
 
 /**
   Somebody else can use this to be notified when the estop state changes

--- a/irq_handlers.c
+++ b/irq_handlers.c
@@ -54,13 +54,12 @@ CH_IRQ_HANDLER(HW_ENC_EXTI_ISR_VEC) {
 }
 
 CH_IRQ_HANDLER(HW_ESTOP_EXTI_ISR_VEC) {
-  CH_IRQ_PROLOGUE();
+  if (EXTI_GetITStatus(HW_ESTOP_EXTI_LINE) != RESET) {
+    estop_state_change_handler();
 
-  estop_state_change_handler();
-
-  // Clear the EXTI line pending bit
-  EXTI_ClearITPendingBit(HW_ESTOP_EXTI_LINE);
-  CH_IRQ_EPILOGUE();
+    // Clear the EXTI line pending bit
+    EXTI_ClearITPendingBit(HW_ESTOP_EXTI_LINE);
+  }
 }
 
 CH_IRQ_HANDLER(HW_ENC_TIM_ISR_VEC) {

--- a/linux_impl/README.md
+++ b/linux_impl/README.md
@@ -1,0 +1,28 @@
+# linux_impl #
+
+Contains the Linux driver for communication with the VESC.
+
+## Communication ##
+
+This driver uses the `serial::Serial` library and is intended for use along with an FTDI chip. In general, `vesc_comm.h` provides a communications interface for the rest of the driver. Currently, `vesc_comm.h` is implemented by `vesc_usb.cpp`. If this driver is to be run on another target platform which doesnt support the `serial::Serial` class, one just need to provide an alternative implementation for `vesc_comm.h` and the rest of the system can remain unchanged.
+
+The driver uses the same packet interface as the VESC firmware (please see the `bldc` README for more info).
+
+## Publishing Feedback and Status ##
+
+Publishing feedback and status messages received from the VESC is achieved through function pointers passed to `vesc::initComm()`. This methodology was selected in order to decouple ROS from the communications logic in case we decide to remove the ROS component from the Linux driver.
+
+
+## XML Config, Hall Table Detection over UART ##
+
+The driver contains code to both flash an XML config file as well as detect hall table parameters over UART as an alternative to using the VESC tool connected via USB.
+
+The following configuration executables are avilable in `pff-ros-ws/devel/lib/vesc_driver/`. All of the executables take 2 arguments: `port` and `config_file`:
+
+~~~
+config_xml      -> read an XML motor configuration file, and send it to the VESC
+config_hall_foc -> perform FOC hall sensor detection routine, save values in provided XML config file
+config_all      -> run config_hall_foc, then configure with config_xml
+~~~
+
+**NOTE** `config_hall_foc` does NOT send over the XML file. It just updates local configuration. `config_all` will perform the hall detection routine, save the hall table to the pointed-to config file, and upload the resulting configuration to the VESC.

--- a/linux_impl/src/vesc_driver/msg/Feedback.msg
+++ b/linux_impl/src/vesc_driver/msg/Feedback.msg
@@ -4,17 +4,4 @@ int32 measured_velocity
 int32 measured_position
 float32 supply_voltage
 float32 supply_current
-
-
-# use logical AND on the switch flags eg. switch_flag = 5 means that both
-# ESTOP and REV_LIMIT are set...
-#
-#  if (feedback_message & ESTOP)
-#    // estop is set
-#  if (feedback_message & REV_LIMIT)
-#    // rev_limit is set
-#
-uint32 REV_LIMIT = 1
-uint32 FWD_LIMIT = 2
-uint32 ESTOP     = 4
-uint32 switch_flags
+uint8 estop

--- a/linux_impl/src/vesc_driver/msg/Status.msg
+++ b/linux_impl/src/vesc_driver/msg/Status.msg
@@ -7,5 +7,3 @@ uint8 FAULT_CODE_OVER_TEMP_FET = 5
 uint8 FAULT_CODE_OVER_TEMP_MOTOR = 6
 
 uint32 fault_code
-uint32 temp
-bool limits_set

--- a/linux_impl/src/vesc_driver/src/vesc_ros.cpp
+++ b/linux_impl/src/vesc_driver/src/vesc_ros.cpp
@@ -102,7 +102,7 @@ void processFeedback(const mc_feedback &fb)
   msg.measured_position       = fb.measured_position;
   msg.supply_voltage          = fb.supply_voltage;
   msg.supply_current          = fb.supply_current;
-  msg.switch_flags            = fb.switch_flags;
+  msg.estop                   = fb.estop;
 
   feedback_to_publish[fbBufWriteIndex] = msg;
   fbBufWriteIndex = (fbBufWriteIndex + 1) % FEEDBACK_BUF_SIZE;
@@ -112,8 +112,6 @@ void processStatus(const mc_status &s)
 {
   vesc_driver::Status msg;
   msg.fault_code = s.fault_code;
-  msg.temp = s.temp;
-  msg.limits_set = s.limits_set;
 
   status_to_publish[statusBufWriteIndex] = msg;
   statusBufWriteIndex = (statusBufWriteIndex + 1) % FEEDBACK_BUF_SIZE;

--- a/linux_impl/src/vesc_driver/src/vesc_usb.cpp
+++ b/linux_impl/src/vesc_driver/src/vesc_usb.cpp
@@ -89,8 +89,6 @@ static size_t readBytes(uint8_t * dest, unsigned int max_bytes)
 static void serialProcessPacket(unsigned char *data, unsigned int length)
 {
   mc_cmd cmd;
-  mc_config_current_pid_union i_pid;
-  // float value;
   char msg[80];
 
   switch (data[0])
@@ -138,12 +136,6 @@ static void serialProcessPacket(unsigned char *data, unsigned int length)
           ROS_ERROR_STREAM("Received CONTROL_WRITE of unknown type " << data[1]);
           break;
       }
-      break;
-
-    case CONFIG_WRITE_CURRENT_PID:
-      extractCurrentPIDDataF(i_pid, data);
-      ROS_WARN_STREAM("Received current PID echo: kp = " << i_pid.config.kp 
-        << ", ki = " << i_pid.config.ki << ", kd = " << i_pid.config.kd);
       break;
 
     /**

--- a/mc_interface.c
+++ b/mc_interface.c
@@ -399,55 +399,6 @@ void mc_interface_set_pid_pos(float pos) {
 	}
 }
 
-void mc_interface_set_pid_pos_src(int (*pos_src)(void)) {
-  mcpwm_foc_set_pid_pos_src(pos_src);
-}
-
-void mc_interface_handle_timeout(float timeout_brake_current) {
-	mc_interface_unlock();
-
-	switch(m_conf.motor_type) {
-
-		// handling for our own current pid loop
-		case MOTOR_TYPE_BLDC:
-			mcpwm_set_pid_current(0.0);
-			break;
-
-		case MOTOR_TYPE_FOC:
-			mcpwm_foc_set_current(0.0);
-
-		default:
-			break;
-	}
-
-	// default behavior
-	mc_interface_set_brake_current(timeout_brake_current);
-}
-
-void mc_interface_set_pid_current_parameters(float kp, float ki, float kd) {
-
-	// only intended for use with PFF BLDC operation
-	if (m_conf.motor_type != MOTOR_TYPE_BLDC)
-		return;
-	mcpwm_set_pid_current_parameters(kp, ki, kd);
-}
-
-void mc_interface_set_pid_current(float setpoint_amps)
-{
-	// only intended for use with PFF BLDC operation
-	if (m_conf.motor_type != MOTOR_TYPE_BLDC)
-		return;
-	mcpwm_set_pid_current(setpoint_amps);
-}
-
-float mc_interface_get_last_pid_current_output(void)
-{
-	// only intended for use with PFF BLDC operation
-	if (m_conf.motor_type != MOTOR_TYPE_BLDC)
-		return -1.12412123123;
-	return mcpwm_get_last_pid_current_output();
-}
-
 void mc_interface_set_current(float current) {
 	if (mc_interface_try_input()) {
 		return;

--- a/mc_interface.h
+++ b/mc_interface.h
@@ -66,7 +66,6 @@ float mc_interface_read_reset_avg_motor_current(void);
 float mc_interface_read_reset_avg_input_current(void);
 float mc_interface_read_reset_avg_id(void);
 float mc_interface_read_reset_avg_iq(void);
-void mc_interface_set_pid_pos_src(int (*pos_src)(void));
 float mc_interface_get_pid_pos_set(void);
 float mc_interface_get_pid_pos_now(void);
 float mc_interface_get_last_sample_adc_isr_duration(void);
@@ -81,11 +80,6 @@ void mc_interface_mc_timer_isr(void);
 
 // Interrupt handlers
 void mc_interface_adc_inj_int_handler(void);
-
-void mc_interface_set_pid_current_parameters(float kp, float ki, float kd);
-void mc_interface_set_pid_current(float setpoint_amps);
-float mc_interface_get_last_pid_current_output(void);
-void mc_interface_handle_timeout(float timeout_brake_current);
 
 // External variables
 extern volatile uint16_t ADC_Value[];

--- a/mcpwm.h
+++ b/mcpwm.h
@@ -67,10 +67,6 @@ mc_rpm_dep_struct mcpwm_get_rpm_dep(void);
 bool mcpwm_is_dccal_done(void);
 void mcpwm_switch_comm_mode(mc_comm_mode next);
 
-void mcpwm_set_pid_current_parameters(float kp, float ki, float kd);
-void mcpwm_set_pid_current(float amps);
-float mcpwm_get_last_pid_current_output(void);
-
 // Interrupt handlers
 void mcpwm_adc_inj_int_handler(void);
 void mcpwm_adc_int_handler(void *p, uint32_t flags);

--- a/mcpwm_foc.c
+++ b/mcpwm_foc.c
@@ -137,12 +137,6 @@ static THD_WORKING_AREA(timer_thread_wa, 2048);
 static THD_FUNCTION(timer_thread, arg);
 static volatile bool timer_thd_stop;
 
-
-
-// aubrey functions
-static int default_pos_fun(void) {return m_tachometer;}
-static int (*pos_fun)(void) = default_pos_fun;
-
 // Macros
 #ifdef HW_HAS_3_SHUNTS
 #define TIMER_UPDATE_DUTY(duty1, duty2, duty3) \
@@ -570,10 +564,6 @@ void mcpwm_foc_set_pid_pos(float pos) {
 	if (m_state != MC_STATE_RUNNING) {
 		m_state = MC_STATE_RUNNING;
 	}
-}
-
-void mcpwm_foc_set_pid_pos_src(int (*pos_src)(void)) {
-  pos_fun = pos_src;
 }
 
 /**

--- a/mcpwm_foc.h
+++ b/mcpwm_foc.h
@@ -42,7 +42,6 @@ void mcpwm_foc_set_handbrake(float current);
 void mcpwm_foc_set_openloop(float current, float rpm);
 float mcpwm_foc_get_duty_cycle_set(void);
 float mcpwm_foc_get_duty_cycle_now(void);
-void mcpwm_foc_set_pid_pos_src(int (*pos_src)(void));
 float mcpwm_foc_get_pid_pos_set(void);
 float mcpwm_foc_get_pid_pos_now(void);
 float mcpwm_foc_get_switching_frequency_now(void);

--- a/packet.h
+++ b/packet.h
@@ -23,7 +23,7 @@
 #include <stdint.h>
 
 // Settings
-#define PACKET_RX_TIMEOUT		1000
+#define PACKET_RX_TIMEOUT		5
 #define PACKET_HANDLERS			2
 #define PACKET_MAX_PL_LEN		1024
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,22 +1,22 @@
 #! /usr/bin/env bash
 
-# find the directory of this script, then go back one directory to find the base of the repo
-# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
-SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPTS_DIR && cd ..
-REPO_DIR=$(pwd)
+BLDC_DIR=$HOME/bldc-pff
+LINUX_IMPL_DIR=$BLDC_DIR/linux_impl
+START_DIR=$(pwd)
 
-vesc_dir=$HOME/pff-bldc
-linux_dir=$REPO_DIR/linux_impl
 
-function stop_build {
-	printf "$1"
-	printf "\nFix errors and rerun.\n"
-	cd $start_dir
-	exit 1
+function exit_build {
+    printf "$1"
+    printf "\n\n"
+    exit 1
 }
 
-printf "\n\n\t\tBuilding VESC firmware...\n\n"
-cd $REPO_DIR && (make || stop_build "VESC build failed!")
-printf "\n\n\t\tBuilding Linux driver...\n\n"
-cd $linux_dir && (catkin_make || stop_build "catkin build failed!")
+# build the vesc code first
+printf "\n\n\tBuilding VESC firmware...\n\n"
+cd $BLDC_DIR && (make || exit_build "pff-bldc: build failed!")
+
+# then, build linux driver
+printf "\n\n\tBuilding Linux driver...\n\n"
+cd $LINUX_IMPL_DIR && (catkin_make || exit_build "vesc_driver: build failed!")
+source $LINUX_IMPL_DIR/devel/setup.bash
+cd $START_DIR

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+
+# find the directory of this script, then go back one directory to find the base of the repo
+# https://stackoverflow.com/questions/59895/getting-the-source-directory-of-a-bash-script-from-within
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $SCRIPTS_DIR && cd ..
+REPO_DIR=$(pwd)
+
+vesc_dir=$HOME/pff-bldc
+linux_dir=$REPO_DIR/linux_impl
+
+function stop_build {
+	printf "$1"
+	printf "\nFix errors and rerun.\n"
+	cd $start_dir
+	exit 1
+}
+
+printf "\n\n\t\tBuilding VESC firmware...\n\n"
+cd $REPO_DIR && (make || stop_build "VESC build failed!")
+printf "\n\n\t\tBuilding Linux driver...\n\n"
+cd $linux_dir && (catkin_make || stop_build "catkin build failed!")

--- a/timeout.c
+++ b/timeout.c
@@ -67,7 +67,8 @@ static THD_FUNCTION(timeout_thread, arg) {
 
 	for(;;) {
 		if (timeout_msec != 0 && chVTTimeElapsedSinceX(last_update_time) > MS2ST(timeout_msec)) {
-		    mc_interface_handle_timeout(timeout_brake_current);
+			mc_interface_unlock();
+			mc_interface_set_brake_current(timeout_brake_current);
 			has_timeout = true;
 		} else {
 			has_timeout = false;

--- a/timeout.c
+++ b/timeout.c
@@ -67,7 +67,7 @@ static THD_FUNCTION(timeout_thread, arg) {
 
 	for(;;) {
 		if (timeout_msec != 0 && chVTTimeElapsedSinceX(last_update_time) > MS2ST(timeout_msec)) {
-      mc_interface_handle_timeout(timeout_brake_current);
+		    mc_interface_handle_timeout(timeout_brake_current);
 			has_timeout = true;
 		} else {
 			has_timeout = false;


### PR DESCRIPTION
- cleanup application UART code (remove unused functions, naming conventions, state machine)
- documentation in READMEs and comments in code
- use a timer interrupt for estop debounce
